### PR TITLE
add network cut / restore helpers vm

### DIFF
--- a/data_platform_helpers/tests_helpers/vms/ha_helpers.py
+++ b/data_platform_helpers/tests_helpers/vms/ha_helpers.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+from pytest_operator.plugin import OpsTest
+
+
+def cut_network_from_unit_with_ip_change(machine_name: str) -> None:
+    """Cut network from a lxc container in a way the changes the IP.
+
+    Args:
+        machine_name: lxc container hostname
+    """
+    # apply a mask (device type `none`)
+    cut_network_command = f"lxc config device add {machine_name} eth0 none"
+    subprocess.check_call(cut_network_command.split())
+
+
+async def cut_network_from_unit_without_ip_change(ops_test: OpsTest, machine_name: str) -> None:
+    """Cut network from a lxc container (without causing the change of the unit IP address)."""
+
+    override_command = f"lxc config device override {machine_name} eth0"
+    try:
+        subprocess.check_call(override_command.split())
+    except subprocess.CalledProcessError:
+        # Ignore if the interface was already overridden.
+        pass
+
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress=0kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress=1kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority=10"
+    subprocess.check_call(limit_set_command.split())
+
+
+async def restore_network_for_unit_with_ip_change(machine_name: str) -> None:
+    """Restore network from a lxc container by removing mask from eth0."""
+    restore_network_command = f"lxc config device remove {machine_name} eth0"
+    subprocess.check_call(restore_network_command.split())
+
+
+async def restore_network_for_unit_without_ip_change(machine_name: str) -> None:
+    """Restore network from a lxc container (without causing the change of the unit IP address)."""
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority="
+    subprocess.check_call(limit_set_command.split())
+
+
+# TODO add these network helpers:
+# get_controller_machine
+# is_machine_reachable_from
+# wait_network_restore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-platform-helpers"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Mia Altieri <mgaltier200@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Issue
Many charms use network cut in their tests (inside and outside of HA tests) however each charm has some version of this function with some small slight variations.

This means when there is a failure in this test all charms must be updated individually

## Solution
Add shared code for this bit so that when there are issues the charm can be updated directly 