### PR TITLE
[DPE-7820]: remove lru cache from _get_sorted_statuses

### DIFF
--- a/data_platform_helpers/advanced_statuses/handler.py
+++ b/data_platform_helpers/advanced_statuses/handler.py
@@ -153,7 +153,6 @@ class StatusHandler(Object):
                 logger.info("Overriding critical status %s", critical_statuses)
                 self._object(scope).status = ops_status
 
-
     def _get_sorted_statuses(self, scope: Scope) -> list[tuple[str, StatusObject]]:
         """Retrieves the list of all statuses and sorts them according to DA-147 and DA-161.
 

--- a/data_platform_helpers/advanced_statuses/handler.py
+++ b/data_platform_helpers/advanced_statuses/handler.py
@@ -188,7 +188,9 @@ class StatusHandler(Object):
             ),
         )
 
-    def _get_critical_statuses(self, scope: Scope, all_statuses: list[tuple[str, StatusObject]] | None = None) -> list[tuple[str, StatusObject]]:
+    def _get_critical_statuses(
+        self, scope: Scope, all_statuses: list[tuple[str, StatusObject]] | None = None
+    ) -> list[tuple[str, StatusObject]]:
         """Retrieves all critical statuses."""
         """Gets all critical statuses for all components."""
         if all_statuses is None:

--- a/data_platform_helpers/advanced_statuses/handler.py
+++ b/data_platform_helpers/advanced_statuses/handler.py
@@ -188,16 +188,17 @@ class StatusHandler(Object):
             ),
         )
 
-    def _get_critical_statuses(self, scope: Scope) -> list[tuple[str, StatusObject]]:
+    def _get_critical_statuses(self, scope: Scope, all_statuses: list[tuple[str, StatusObject]] | None = None) -> list[tuple[str, StatusObject]]:
         """Retrieves all critical statuses."""
         """Gets all critical statuses for all components."""
-        all_statuses = self._get_sorted_statuses(scope)
+        if all_statuses is None:
+            all_statuses = self._get_sorted_statuses(scope)
         return [status for status in all_statuses if status[1].approved_critical_component]
 
     def _process_on_scope_statuses(self, scope: Scope, event: CollectStatusEvent):
         """The core logic of the status handling for a given scope."""
         all_statuses = self._get_sorted_statuses(scope)
-        critical_statuses = self._get_critical_statuses(scope)
+        critical_statuses = self._get_critical_statuses(scope, all_statuses=all_statuses)
 
         if critical_statuses:
             # When we have critical statuses, we display it right away.

--- a/data_platform_helpers/advanced_statuses/handler.py
+++ b/data_platform_helpers/advanced_statuses/handler.py
@@ -153,7 +153,7 @@ class StatusHandler(Object):
                 logger.info("Overriding critical status %s", critical_statuses)
                 self._object(scope).status = ops_status
 
-    @lru_cache
+
     def _get_sorted_statuses(self, scope: Scope) -> list[tuple[str, StatusObject]]:
         """Retrieves the list of all statuses and sorts them according to DA-147 and DA-161.
 


### PR DESCRIPTION
Fixes #34 
This pull request includes a small change to the `data_platform_helpers/advanced_statuses/handler.py` file. It removes the `@lru_cache` decorator from the `_get_sorted_statuses` method, likely to address caching or performance concerns.