### PR TITLE
[DPE-7821] Fix json format for status-detail action

### DIFF
--- a/data_platform_helpers/__init__.py
+++ b/data_platform_helpers/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+# ruff: noqa
+"""Data platform helpers"""
+
+import advanced_statuses
+
+__all__ = ("advanced_statuses",)

--- a/data_platform_helpers/__init__.py
+++ b/data_platform_helpers/__init__.py
@@ -1,8 +1,0 @@
-# Copyright 2025 Canonical Ltd.
-# See LICENSE file for licensing details.
-# ruff: noqa
-"""Data platform helpers"""
-
-import advanced_statuses
-
-__all__ = ("advanced_statuses",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-platform-helpers"
-version = "0.1.6"
+version = "0.1.7"
 description = ""
 authors = ["Mia Altieri <mgaltier200@gmail.com>"]
 readme = "README.md"

--- a/tests/unit/test_advanced_statuses_handler.py
+++ b/tests/unit/test_advanced_statuses_handler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import json
 from typing import Any
 
 import pytest
@@ -15,7 +16,6 @@ from data_platform_helpers.advanced_statuses.components import StatusesState
 from data_platform_helpers.advanced_statuses.handler import StatusHandler
 from data_platform_helpers.advanced_statuses.models import (
     StatusObject,
-    StatusObjectDict,
 )
 from data_platform_helpers.advanced_statuses.protocol import (
     ManagerStatusProtocol,
@@ -156,17 +156,14 @@ def test_multiple_statuses(context: testing.Context[MyCharm], state: testing.Sta
 
     context.run(context.on.action("status-detail"), out_bis)
     json_output = context.action_results["json-output"]
-    app_statuses = StatusObjectDict.model_validate_json(json_output['app'])
-    unit_statuses = StatusObjectDict.model_validate_json(json_output['unit'])
-    assert len(app_statuses.root["my-charm"].root) == 2
-    assert len(unit_statuses.root["my-charm"].root) == 1
+    app_statuses = json.loads(json_output["app"])
+    unit_statuses = json.loads(json_output["unit"])
+    assert len(app_statuses) == 2
+    assert len(unit_statuses) == 1
 
-    assert app_statuses.root["my-charm"].root[0].status == "blocked"
-    assert app_statuses.root["my-charm"].root[0].message == "blah"
-    assert app_statuses.root["my-charm"].root[1].status == "maintenance"
-    assert app_statuses.root["my-charm"].root[1].message == "running maintenance"
-    assert unit_statuses.root["my-charm"].root[0].status == "active"
-    assert unit_statuses.root["my-charm"].root[0].message == "running"
+    assert app_statuses[0]["Status"] == "Blocked"
+    assert app_statuses[1]["Status"] == "Maintenance"
+    assert unit_statuses[0]["Status"] == "Active"
 
 
 def test_multiple_components(context: testing.Context[MyCharm], state: testing.State):
@@ -181,18 +178,14 @@ def test_multiple_components(context: testing.Context[MyCharm], state: testing.S
 
     context.run(context.on.action("status-detail"), out_ter)
     json_output = context.action_results["json-output"]
-    app_statuses_by_components = StatusObjectDict.model_validate_json(json_output['app'])
-    unit_statuses_by_components = StatusObjectDict.model_validate_json(json_output['unit'])
-    
-    assert len(app_statuses_by_components.root['my-charm'].root) == 1
-    assert len(app_statuses_by_components.root['other-component'].root) == 1
-    assert len(unit_statuses_by_components.root['my-charm'].root) == 1
-    assert len(unit_statuses_by_components.root['other-component'].root) == 0
+    app_statuses = json.loads(json_output["app"])
+    unit_statuses = json.loads(json_output["unit"])
 
-    assert app_statuses_by_components.root['my-charm'].root[0].status == "maintenance"
-    assert app_statuses_by_components.root['my-charm'].root[0].message == "running maintenance"
-    assert app_statuses_by_components.root['other-component'].root[0].status == "blocked"
-    assert app_statuses_by_components.root['other-component'].root[0].message == "other component failed"
-    assert unit_statuses_by_components.root['my-charm'].root[0].status == "active"
-    assert unit_statuses_by_components.root['my-charm'].root[0].message == "running"
-    assert unit_statuses_by_components.root['other-component'].root == []
+    assert len(app_statuses) == 2
+    assert len(unit_statuses) == 1
+
+    assert app_statuses[0]["Status"] == "Blocked"
+    assert app_statuses[0]["Component Name"] == "other-component"
+    assert app_statuses[1]["Status"] == "Maintenance"
+    assert app_statuses[1]["Component Name"] == "my-charm"
+    


### PR DESCRIPTION
### Refactoring of status handling:
* Updated the JSON output generation to directly serialize `StatusObjectDict` in JSON format, replacing the custom `json_output` method. The `json_output` method was removed as part of this change. [[1]](diffhunk://#diff-c78126af468aa807cc3c88239a843079f3f542bf0ba7da3615c84f8b396991ffL301-R332) [[2]](diffhunk://#diff-c78126af468aa807cc3c88239a843079f3f542bf0ba7da3615c84f8b396991ffL341-L358)

### Testing updates:
* Modified unit tests in `tests/unit/test_advanced_statuses_handler.py` to validate the new `StatusObjectDict` structure. Tests now ensure the correct hierarchy and values for component statuses (`app` and `unit`) using the new model. [[1]](diffhunk://#diff-33306debf7be55312d12bb426d1901edc4e4bfdc3349c440c3a63d6a95433b92L158-R169) [[2]](diffhunk://#diff-33306debf7be55312d12bb426d1901edc4e4bfdc3349c440c3a63d6a95433b92L178-R198)
* Added `StatusObjectDict` to imports in the test file to support the updated test logic.

### Versioning:
* Incremented the package version in `pyproject.toml` from `0.1.6` to `0.1.7` to reflect the changes introduced in this update.